### PR TITLE
feat(event types): add publish unpublish

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ module.exports = ({ env }) => ({
 | trigger.events.url | The model specific url to hit on event trigger. | String | No |
 | trigger.events.params | The model specific params to add on event trigger. | Object `or` Function | No |
 | trigger.events.model | The model to listen for events on. | String | Yes |
-| trigger.events.types | The model events to trigger on. The current supported events are `create`, `update` and `delete` | Array | Yes |
+| trigger.events.types | The model events to trigger on. The current supported events are `create`, `update`, `delete`, `publish` and `unpublish`. Publish/Unpublish is only supported for non media models. | Array | Yes |
 
 ## Usage
 

--- a/server/config/schema.js
+++ b/server/config/schema.js
@@ -37,7 +37,7 @@ const pluginConfigSchema = yup
 							model: yup.string().required('A model name is required'),
 							types: yup
 								.array()
-								.of(yup.string().oneOf(['create', 'update', 'delete']))
+								.of(yup.string().oneOf(['create', 'update', 'delete','publish','unpublish']))
 								.required('types is required'),
 						})
 					)


### PR DESCRIPTION
This PR introduces the following change(s):
- adds publush and unpublish as valid event types for non media models