### PR TITLE
🐛 fix(event): media does not trigger build

### DIFF
--- a/server/utils/setupEventWebhook.js
+++ b/server/utils/setupEventWebhook.js
@@ -37,7 +37,7 @@ const setupEventWebhook = (strapi, settings) => {
 		strapi.eventHub.on(event, (data) => {
 			// build on data.media (nothing to verify since it wouldn't get here without having the event setup on the event listener)
 			// otherwise, build on matching models
-			if (!!data.media || eventModels.includes(data.model)) {
+			if (data.media || eventModels.includes(data.model)) {
 				getPluginService(strapi, 'buildService').build({
 					record: data.entry,
 					settings,

--- a/server/utils/setupEventWebhook.js
+++ b/server/utils/setupEventWebhook.js
@@ -35,7 +35,9 @@ const setupEventWebhook = (strapi, settings) => {
 
 	for (const [event, eventModels] of Object.entries(events)) {
 		strapi.eventHub.on(event, (data) => {
-			if (eventModels.includes(data.model)) {
+			// build on data.media (nothing to verify since it wouldn't get here without having the event setup on the event listener)
+			// otherwise, build on matching models
+			if (!!data.media || eventModels.includes(data.model)) {
 				getPluginService(strapi, 'buildService').build({
 					record: data.entry,
 					settings,


### PR DESCRIPTION
It looks like the `media.create`, `media.update`, and `media.delete` events were firing. But they would never pass the logic on line 38 because the data for those events don't include a `model` property. However, they have a `media` property that we can use to confirm if the media event and use that to trigger a build.

Resolves #22 