### PR TITLE
✨ feat(event): add model wildcard trigger

### DIFF
--- a/server/utils/setupEventWebhook.js
+++ b/server/utils/setupEventWebhook.js
@@ -35,12 +35,17 @@ const setupEventWebhook = (strapi, settings) => {
 
 	for (const [event, eventModels] of Object.entries(events)) {
 		strapi.eventHub.on(event, (data) => {
-			if (eventModels.includes(data.model)) {
-				getPluginService(strapi, 'buildService').build({
-					record: data.entry,
-					settings,
-					trigger: { type: 'event', data: { type: event, ...data } },
-				});
+			// never trigger on 'log' because it causes an endless loop since the build always creates a log when it's done
+			if (data.model !== 'log') {
+				// build on any model update if event model is '*'
+				// otherwise, build on matching models
+				if (eventModels.includes('*') || eventModels.includes(data.model)) {
+					getPluginService(strapi, 'buildService').build({
+						record: data.entry,
+						settings,
+						trigger: { type: 'event', data: { type: event, ...data } },
+					});
+				}
 			}
 		});
 	}

--- a/server/utils/setupEventWebhook.js
+++ b/server/utils/setupEventWebhook.js
@@ -36,7 +36,8 @@ const setupEventWebhook = (strapi, settings) => {
 	for (const [event, eventModels] of Object.entries(events)) {
 		strapi.eventHub.on(event, (data) => {
 			// never trigger on 'log' because it causes an endless loop since the build always creates a log when it's done
-			if (data.model !== 'log') {
+			// don't trigger on 'file', because it will double fire on 'media' type files
+			if (data.model !== 'log' && data.model !== 'file') {
 				// build on any model update if event model is '*'
 				// otherwise, build on matching models
 				if (eventModels.includes('*') || eventModels.includes(data.model)) {


### PR DESCRIPTION
Add the ability to include wildcards (`*`) in the event trigger model in the plugin config. This can be achieved using the following format in the plugin config...
```
      trigger: {
        type: 'event',
        events: [
          {
            model: '*',
            types: ['create', 'update', 'delete', 'publish', 'unpublish'],
          }
        ]
      }
```

Resolves #24 