### PR TITLE
chore(npm): remove docs from bundle

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -20,3 +20,6 @@ npm-debug.log
 
 # github
 .github
+
+# docs
+docs


### PR DESCRIPTION
This PR removes the docs folder from the published npm package/bundle